### PR TITLE
docs: improve readme for publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Please review [Ansible Community Guide](https://docs.ansible.com/ansible/devel/community/index.html)
+and [Developing collections](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections)
+guide prior to contributing to this collection.
+
+# Environment setup
+
+Create virtualenv and install dependencies:
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+# Running tests
+
+Install test dependencies:
+```
+# source venv/bin/activate
+pip install -r test_requirements.txt
+```
+
+Run tests:
+```
+# source venv/bin/activate
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Rulebook example of creating ServiceNow Incidents out of selected Insights event
 * [Advisor recommendations](https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_rhel_configuration_issues_using_the_red_hat_insights_advisor_service/index)
 * newly detected [vulnerabilities](https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_monitoring_security_vulnerabilities_on_rhel_systems/index)
 * detected vulnerabilites with a known exploit
+* system compliance below threshold
 
 Prerequisites:
 * `servicenow.itsm` collection installed

--- a/README.md
+++ b/README.md
@@ -8,26 +8,24 @@ This collection contains the event source plugin for receiving events out of
 [Red Hat Insights](https://console.redhat.com/insights).
 
 
-## Installation
+## Requirements
 
-From source:
+* [Ansible Rulebook](https://ansible-rulebook.readthedocs.io/en/stable/installation.html) >=0.13.0
+
+Install dependencies required by the collection (adjust path to collection if necessary):
 ```
-git clone https://github.com/RedHatInsights/ansible-collections-eda.git
-ansible-galaxy collection install -U ./ansible-collections-eda
-```
-From Ansible Galaxy:
-```
-ansible-galaxy collection install redhatinsights.eda ansible-collections-eda
+pip3 install -r ~/.ansible/collections/ansible_collections/redhatinsights/eda/requirements.txt
 ```
 
+
+## Usage
 
 To set up an integration with Red Hat Insights please follow
 [official documentation](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/configuring_notifications_and_integrations_on_the_red_hat_hybrid_cloud_console/index).
 Use integration type "Event-Driven Ansible" from the dropdown.
 
-## Usage
-
 ```yaml
+# rulebook
   sources:
     - redhatinsights.eda.insights:
         host:     # hostname to listen to. (default: 127.0.0.1)
@@ -39,8 +37,6 @@ Use integration type "Event-Driven Ansible" from the dropdown.
 ```
 
 ## Examples
-
-Prerequisite for running examples is installed [Ansible Rulebook](https://ansible-rulebook.readthedocs.io/en/stable/installation.html).
 
 
 To run an example execute:
@@ -189,3 +185,8 @@ Playbooks:
 
 See [CONTRIBUTING](https://github.com/RedHatInsights/ansible-collections-eda/CONTRIBUTING.md) document.
 
+## License
+
+Apache 2.0
+
+See [LICENSE](https://github.com/RedHatInsights/ansible-collections-eda/LICENSE) to see the full text.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Event-Driven Ansible for Red Hat Insights
 
-`redhatinsights.eda.insights`
-
-
-## Description
+[![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
+[![CI](https://github.com/RedHatInsights/ansible-collections-eda/actions/workflows/test.yaml/badge.svg)](https://github.com/RedHatInsights/ansible-collections-eda/actions/workflows/test.yaml)
+[![Integration tests](https://github.com/RedHatInsights/ansible-collections-eda/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/RedHatInsights/ansible-collections-eda/actions/workflows/integration-tests.yaml)
 
 This collection contains the event source plugin for receiving events out of
 [Red Hat Insights](https://console.redhat.com/insights).

--- a/README.md
+++ b/README.md
@@ -186,27 +186,7 @@ Playbooks:
     loop: "{{ ansible_eda.event.payload.events | default([]) }}"
 ```
 
-## Development
+## Contributing
 
-### Setting up environment
+See [CONTRIBUTING](https://github.com/RedHatInsights/ansible-collections-eda/CONTRIBUTING.md) document.
 
-Create virtualenv and install dependencies:
-```
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-
-### Running tests
-
-Install test dependencies:
-```
-# source venv/bin/activate
-pip install -r test_requirements.txt
-```
-
-Run tests:
-```
-# source venv/bin/activate
-pytest
-```


### PR DESCRIPTION
Align readme to common structure used by majority of collections. Installation instructions would be given by Galaxy and Automation Hub. Development stuff have been moved to CONTRIBUTING.md, as the readme would be read mostly by users.

EVNT-868