### PR TITLE
ci: tag and publish to galaxy

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -1,0 +1,57 @@
+name: Tag on version change
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  version_tag:
+    name: Version tag if not exist
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tagging.outputs.version }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Tag if not exist
+        id: tagging
+        run: |
+          version=$(grep -P -o "(?<=^version: )\d+\.\d+\.\d+" galaxy.yml)
+          tag=v${version}
+          git fetch --tags
+          if [[ "$(git tag -l "${tag}")" == "" ]]; then
+            git tag "${tag}"
+            git push origin "${tag}"
+            echo "version=$version" >> $GITHUB_OUTPUT
+          else
+            echo "Tag exist, skipping release"
+          fi
+  release:
+    name: Release if tagged
+    needs: version_tag
+    if: needs.version_tag.outputs.version != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/redhatinsights/eda
+
+      - name: Install ansible-base
+        run: pip install ansible
+
+      - name: Run sanity tests
+        # symlinks test are skipped, as the tests/integration/.collections
+        # has a directory symlink to self-link for a local testing.
+        working-directory: ansible_collections/redhatinsights/eda
+        run: ansible-test sanity --skip-test symlinks
+
+      - name: Build
+        working-directory: ansible_collections/redhatinsights/eda
+        run: ansible-galaxy collection build
+
+      - name: Publish to Galaxy
+        working-directory: ansible_collections/redhatinsights/eda
+        run:
+          ansible-galaxy collection publish --api-key="${{ secrets.ANSIBLE_GALAXY_APIKEY }}" redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,16 @@ Run tests:
 # source venv/bin/activate
 pytest
 ```
+
+## Publishing
+
+To publish a new version of the collection increase the `version` within [`galaxy.yml`](galaxy.yml)
+creating a pull request. Versions must follow [Semantic Versioninig](https://semver.org/)
+guidelines.
+
+The collection is published to [Ansible Galaxy](https://galaxy.ansible.com/redhatinsights/eda)
+automatically with GitHub action [tag-and-release](.github/workflows/tag-and-release.yaml).
+The action tags latest commit with a version tag from [`galaxy.yml`](galaxy.yml)'s version value, builds the collection and uploads it. Version tags follow the format: `vX.Y.Z`.
+
+Note: that the GitHub project requires a valid Ansible Galaxy API Key set as `ANSIBLE_GALAXY_APIKEY`
+by an administrator.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -63,3 +63,4 @@ build_ignore:
 - venv
 - .pytest_cache
 - tests/integration/.collections
+- tests/output


### PR DESCRIPTION
Creates Github workflow that would tag a new version as a tag, and for new versions/tags it would build the collection and publish it to Ansible Galaxy.

ANSIBLE_GALAXY_APIKEY secret is required to be set on the project.

EVNT-867