### PR TITLE
ci: ansible lint and import checks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,17 @@
+---
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option are parsed relative to the CWD of execution.
+exclude_paths:
+  - .github/
+
+# Ansible-lint is able to recognize and load skip rules stored inside
+# `.ansible-lint-ignore` (or `.config/ansible-lint-ignore.txt`) files.
+# To skip a rule just enter filename and tag, like "playbook.yml package-latest"
+# on a new line.
+# Optionally you can add comments after the tag, prefixed by "#". We discourage
+# the use of skip_list below because that will hide violations from the output.
+# When putting ignores inside the ignore file, they are marked as ignored, but
+# still visible, making it easier to address later.
+skip_list:
+  - galaxy[version-incorrect]

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -38,8 +38,8 @@ jobs:
         with:
           path: ansible_collections/redhatinsights/eda
 
-      - name: Install ansible-base
-        run: pip install ansible
+      - name: Install ansible-base and galaxy-importer
+        run: pip install ansible galaxy-importer
 
       - name: Run sanity tests
         working-directory: ansible_collections/redhatinsights/eda
@@ -48,6 +48,11 @@ jobs:
       - name: Build
         working-directory: ansible_collections/redhatinsights/eda
         run: ansible-galaxy collection build
+
+      - name: Run import checks
+        working-directory: ansible_collections/redhatinsights/eda
+        run:
+          python -m galaxy_importer.main redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
 
       - name: Publish to Galaxy
         working-directory: ansible_collections/redhatinsights/eda

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,3 +43,22 @@ jobs:
       - name: Run unit tests
         run: ansible-test units --venv
         working-directory: ansible_collections/redhatinsights/eda
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ansible_collections/
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/redhatinsights/eda
+
+      - name: Install ansible
+        run: python -m pip install ansible-lint
+
+      - name: Run ansible-lint
+        run: ansible-lint
+        working-directory: ansible_collections/redhatinsights/eda


### PR DESCRIPTION
Adds ansible-lint config to exclude `.github/` folder and `galaxy[version-incorrect]` rule (until major release).

Linter is run in CI.

Adds import checks before publishing to Ansible Galaxy.

EVNT-868