### PR TITLE
feat: bind to all interfaces by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use integration type "Event-Driven Ansible" from the dropdown.
 # rulebook
   sources:
     - redhatinsights.eda.insights:
-        host:     # hostname to listen to. (default: 127.0.0.1)
+        host:     # hostname to listen to. (default: 0.0.0.0)
         port:     # TCP port to listen to. (default: 5000)
         token:    # secret token.
         certfile: # (optional) path to a certificate file to enable TLS support
@@ -69,7 +69,6 @@ Prerequisites:
   hosts: localhost
   sources:
     - redhatinsights.eda.insights:
-        host: 0.0.0.0
         token: "{{ SECRET }}"
   rules:
     - name: match advisor recommendation event

--- a/extensions/eda/plugins/event_source/insights.py
+++ b/extensions/eda/plugins/event_source/insights.py
@@ -5,7 +5,7 @@ An ansible-rulebook event source module for receiving Red Hat Insights events.
 
 Arguments:
     host:     The hostname to listen to. Set to 0.0.0.0 to listen on all
-              interfaces. Defaults to 127.0.0.1
+              interfaces. Defaults to 0.0.0.0
     port:     The TCP port to listen to.  Defaults to 5000
     token:    The optional authentication token expected from client
     certfile: The optional path to a certificate file to enable TLS support
@@ -98,7 +98,7 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     await runner.setup()
     site = web.TCPSite(
         runner,
-        args.get("host") or "localhost",
+        args.get("host") or "0.0.0.0",
         args.get("port") or 5000,
         ssl_context=context,
     )


### PR DESCRIPTION
Bind the Insights EDA source to all interfaces by default, to have it available when running from a container (or AAP).

EVNT-869