### PR TITLE
fix: comply with EDA partner testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,3 +62,22 @@ jobs:
       - name: Run ansible-lint
         run: ansible-lint
         working-directory: ansible_collections/redhatinsights/eda
+
+  tox-eda-testing:
+    name: EDA Partner Testing (Tox)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ansible_collections/
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/redhatinsights/eda
+
+      - name: Install deps
+        run: python -m pip install tox
+      - name: Run tox
+        working-directory: ansible_collections/redhatinsights/eda
+        run: |
+          python -m tox

--- a/extensions/eda/plugins/event_source/insights.py
+++ b/extensions/eda/plugins/event_source/insights.py
@@ -1,9 +1,9 @@
-"""
-insights.py
+"""insights.py.
 
 An ansible-rulebook event source module for receiving Red Hat Insights events.
 
 Arguments:
+---------
     host:     The hostname to listen to. Set to 0.0.0.0 to listen on all
               interfaces. Defaults to 0.0.0.0
     port:     The TCP port to listen to.  Defaults to 5000
@@ -14,21 +14,29 @@ Arguments:
 
 """
 
+# disable typing ruff checks to support older Python versions
+# ruff: noqa: UP006 UP007 UP035
+
 import asyncio
 import logging
 import ssl
-from typing import Any, Callable, Dict
+from collections.abc import Callable
+from typing import Any, Dict, Union
 
 from aiohttp import web
 
-INSIGHTS_TOKEN_HEADER = "X-Insight-Token"
+INSIGHTS_TOKEN_HEADER = "X-Insight-Token"  # noqa: S105
 AUTHORIZATION_HEADER = "Authorization"
 
 logger = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 
-def format_event(payload: Dict[str, Any], endpoint: str, headers: Dict[str, str]):
+def _format_event(
+        payload: Dict[str, Any],
+        endpoint: str,
+        headers: Dict[str, str],
+) -> Dict:
     return {
         "payload": payload,
         "meta": {"endpoint": endpoint, "headers": headers},
@@ -36,34 +44,39 @@ def format_event(payload: Dict[str, Any], endpoint: str, headers: Dict[str, str]
 
 
 @routes.post(r"/{endpoint:.*}")
-async def webhook(request: web.Request):
+async def webhook(request: web.Request) -> web.Response:
+    """Event POST handler."""
     try:
         payload = await request.json()
-    except ValueError:
-        raise web.HTTPBadRequest(reason="Malformed JSON request")
+    except ValueError as ex:
+        raise web.HTTPBadRequest(reason="Malformed JSON request") from ex
 
     endpoint = request.match_info["endpoint"]
     headers = dict(request.headers)
     headers.pop(AUTHORIZATION_HEADER, None)
     headers.pop(INSIGHTS_TOKEN_HEADER, None)
 
-    event = format_event(payload, endpoint, headers)
+    event = _format_event(payload, endpoint, headers)
     await request.app["queue"].put(event)
     return web.Response(text=endpoint)
 
 
-def get_request_token(request: web.Request):
+def _get_request_token(request: web.Request) -> Union[None, str]:
     if INSIGHTS_TOKEN_HEADER in request.headers:
         return request.headers[INSIGHTS_TOKEN_HEADER]
-    elif AUTHORIZATION_HEADER in request.headers:
-        scheme, _sep, token = request.headers[AUTHORIZATION_HEADER].strip().partition(" ")
+    if AUTHORIZATION_HEADER in request.headers:
+        scheme, _sep, token = \
+            request.headers[AUTHORIZATION_HEADER].strip().partition(" ")
         if scheme == "Bearer":
             return token
+        return None
+    return None
 
 
 @web.middleware
-async def authenticate(request: web.Request, handler: Callable):
-    request_token = get_request_token(request)
+async def authenticate(request: web.Request, handler: Callable) -> web.Response:
+    """Middleware for authentication."""
+    request_token = _get_request_token(request)
     if request_token is None:
         raise web.HTTPUnauthorized(reason="Missing authorization token")
     if request_token != request.app["token"]:
@@ -72,7 +85,8 @@ async def authenticate(request: web.Request, handler: Callable):
     return await handler(request)
 
 
-async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+async def main(queue: asyncio.Queue, args: Dict[str, Any]) -> None:
+    """Entrypoint."""
     middlewares = []
     if args.get("token"):
         middlewares = [authenticate]
@@ -91,14 +105,14 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
         try:
             context.load_cert_chain(certfile, keyfile, password)
         except Exception:
-            logger.error("Failed to load certificates. Check they are valid")
+            logger.exception("Failed to load certificates. Check they are valid")
             raise
 
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(
         runner,
-        args.get("host") or "0.0.0.0",
+        args.get("host") or "0.0.0.0",  # noqa: S104
         args.get("port") or 5000,
         ssl_context=context,
     )
@@ -113,10 +127,11 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
 
 
 if __name__ == "__main__":
-    class MockQueue:
-        async def put(self, event):
-            print(event)
+    # pylint: disable=E0401, C0116, R0903, C0115
+    class MockQueue:  # noqa: D101
+        async def put(self, event):  # noqa: D102 ANN001 ANN101 ANN201
+            print(event)  # noqa: T201
 
     asyncio.run(
-        main(MockQueue(), {"port": 2345})
+        main(MockQueue(), {"port": 2345}),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = ruff, pylint-event-source, pylint-event-filter
+requires =
+    ruff
+    pylint
+
+[testenv:ruff]
+deps = ruff
+commands = ruff check --select ALL --ignore INP001 -q extensions/eda/plugins
+
+
+[testenv:pylint-event-source]
+deps =
+    pylint
+    -r requirements.txt
+commands = pylint extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801


### PR DESCRIPTION
Fix linting according to ruff and pylint.
Add tox config and GitHub Action job.

It should follow examples from https://github.com/ansible/eda-partner-testing
Note, that Darglint has been removed, as it is an archived project.

EVNT-872