### PR TITLE
feat: collection build for Automation Hub 

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -54,6 +54,12 @@ jobs:
         run:
           python -m galaxy_importer.main redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
 
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
+          path: redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
+
       - name: Publish to Galaxy
         working-directory: ansible_collections/redhatinsights/eda
         run:

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Install ansible-base and galaxy-importer
         run: pip install ansible galaxy-importer
 
+      - name: Install ansible.posix
+        run: ansible-galaxy collection install ansible.posix
+
       - name: Run sanity tests
         working-directory: ansible_collections/redhatinsights/eda
         run: ansible-test sanity
@@ -64,3 +67,18 @@ jobs:
         working-directory: ansible_collections/redhatinsights/eda
         run:
           ansible-galaxy collection publish --api-key="${{ secrets.ANSIBLE_GALAXY_APIKEY }}" redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
+
+      - name: Build for Automation Hub
+        working-directory: ansible_collections/redhatinsights/eda
+        run: ansible-playbook productize.yml
+
+      - name: Run import checks for hub collection
+        working-directory: ansible_collections/redhatinsights/eda
+        run:
+          python -m galaxy_importer.main redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz
+
+      - name: Upload build for hub
+        uses: actions/upload-artifact@v3
+        with:
+          name: redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz
+          path: redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Install ansible
         run: python -m pip install ansible-lint
 
+      - name: Install ansible.posix
+        run: ansible-galaxy collection install ansible.posix
+
       - name: Run ansible-lint
         run: ansible-lint
         working-directory: ansible_collections/redhatinsights/eda

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,13 @@ The action tags latest commit with a version tag from [`galaxy.yml`](galaxy.yml)
 
 Note: that the GitHub project requires a valid Ansible Galaxy API Key set as `ANSIBLE_GALAXY_APIKEY`
 by an administrator.
+
+### Building for Automation Hub
+
+To build the collection for Automation Hub run playbook `productize.yml` from the project root.
+The playbook would build a collection tar used for publishing to Automation Hub
+under the namespace `redhat` and name `insights_eda`.
+
+```
+ansible-playbook productize.yml
+```

--- a/galaxy.hub.yml
+++ b/galaxy.hub.yml
@@ -1,0 +1,5 @@
+# Contents of this file are merged with galaxy.yml to build collection
+# for Automation Hub
+namespace: redhat
+name: insights_eda
+issues: https://issues.redhat.com/projects/EVNT/issues

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -66,6 +66,7 @@ build_ignore:
   - .gitignore
   - venv
   - .pytest_cache
-  - tests/integration/.collections
+  - .ruff_cache
+  - .tox
   - tests/output
   - .github/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -70,3 +70,5 @@ build_ignore:
   - .tox
   - tests/output
   - .github/
+  - galaxy.hub.yml
+  - productize.yml

--- a/productize.yml
+++ b/productize.yml
@@ -1,0 +1,41 @@
+---
+- name: "Build Hub Collection"
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create build directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: build
+      register: builddir
+
+    - name: Copy build code
+      ansible.posix.synchronize:
+        src: ./
+        dest: "{{ builddir.path }}"
+        rsync_opts:
+          - "--exclude=.git"
+          - "--exclude=venv"
+          - "--exclude=.tox"
+          - "--exclude=.ruff_cache"
+
+    - name: Create Hub Galaxy by merging galaxy.hub.yml
+      ansible.builtin.copy:
+        dest: "{{ builddir.path }}/galaxy.yml"
+        mode: "0644"
+        content: "{{
+          lookup('ansible.builtin.file', builddir.path + '/galaxy.yml') | from_yaml
+          | combine(lookup('ansible.builtin.file', builddir.path + '/galaxy.hub.yml') | from_yaml,
+                    recursive=True)
+          | to_nice_yaml }}"
+
+    - name: Replace usage in README.md
+      ansible.builtin.replace:
+        path: "{{ builddir.path }}/README.md"
+        regexp: 'redhatinsights\.eda\.insights'
+        replace: 'redhat.insights_eda.insights'
+
+    - name: Build collection
+      ansible.builtin.command: 'ansible-galaxy collection build "{{ builddir.path }}"'
+      register: collection_build
+      changed_when: collection_build.rc != 0


### PR DESCRIPTION
Adds a playbook `productize.yml` and `galaxy.hub.yml` to build the collection for Automation Hub under `redhat.insights_eda`.

CI for releasing and building is extended, together with artifacts upload.

EVNT-873