### PR TITLE
fix(docs): numpy docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Event-Driven Ansible for Red Hat Insights Changes
 
+## [0.3.3]
+### Added
+ - docstrings according to Numpy guidelines
+
 ## [0.3.0]
 ### Fixed
  - bind to all interfaces by default

--- a/extensions/eda/plugins/event_source/insights.py
+++ b/extensions/eda/plugins/event_source/insights.py
@@ -74,8 +74,7 @@ def _get_request_token(request: web.Request) -> Union[None, str]:
 
 
 @web.middleware
-async def authenticate(request: web.Request, handler: Callable) -> web.Response:
-    """Middleware for authentication."""
+async def _authenticate(request: web.Request, handler: Callable) -> web.Response:
     request_token = _get_request_token(request)
     if request_token is None:
         raise web.HTTPUnauthorized(reason="Missing authorization token")
@@ -89,7 +88,7 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]) -> None:
     """Entrypoint."""
     middlewares = []
     if args.get("token"):
-        middlewares = [authenticate]
+        middlewares = [_authenticate]
 
     app = web.Application(middlewares=middlewares)
     app["token"] = args.get("token")

--- a/extensions/eda/plugins/event_source/insights.py
+++ b/extensions/eda/plugins/event_source/insights.py
@@ -45,7 +45,24 @@ def _format_event(
 
 @routes.post(r"/{endpoint:.*}")
 async def webhook(request: web.Request) -> web.Response:
-    """Event POST handler."""
+    """Event POST handler.
+
+    Parameters
+    ----------
+    request : web.Request
+        POST request.
+
+    Returns
+    -------
+    web.Response
+        Responses with 200 on succesful event procecing and returns
+        endoint name used to call this API.
+
+    Raises
+    ------
+    HTTPBadRequest
+        If the event is incorrectly formatted to JSON.
+    """
     try:
         payload = await request.json()
     except ValueError as ex:
@@ -85,7 +102,22 @@ async def _authenticate(request: web.Request, handler: Callable) -> web.Response
 
 
 async def main(queue: asyncio.Queue, args: Dict[str, Any]) -> None:
-    """Entrypoint."""
+    """Entrypoint.
+
+    Parameters
+    ----------
+    queue : asyncio.Queue
+        Queue where the received events would be put for processing
+        by Ansible Rulebook.
+    args : Dict[str, Any]
+        Configuration arguments set within rulebook for this EDA source.
+        See full list at the top.
+
+    Raises
+    ------
+    Exception
+        If the configured certificate could not be loaded.
+    """
     middlewares = []
     if args.get("token"):
         middlewares = [_authenticate]

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redhatinsights
 name: eda
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.3.2
+version: 0.3.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ruff, pylint-event-source, pylint-event-filter
+envlist = ruff, darglint, pylint-event-source, pylint-event-filter
 requires =
     ruff
     pylint
@@ -8,6 +8,9 @@ requires =
 deps = ruff
 commands = ruff check --select ALL --ignore INP001 -q extensions/eda/plugins
 
+[testenv:darglint]
+deps = darglint
+commands = darglint -v 2 -s numpy -z full extensions/eda/plugins
 
 [testenv:pylint-event-source]
 deps =


### PR DESCRIPTION
Adds  docstrings  formatted according to Numpy guidelines:
https://numpydoc.readthedocs.io/en/latest/format.html

Docstrings are verified using darglint: https://github.com/terrencepreilly/darglint within CI run using tox.

New patch version is bumped.

EVNT-874