### PR TITLE
fix(license): add NOTICE file specifying Red Had as the owner

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2024 Red Hat, Inc.


### PR DESCRIPTION
As per my email thread, I'd like to comply with the license appendix and add a NOTICE file specifying the owner of the copyright.