### PR TITLE
fix: Update github workflow - update actions/upload-artifact@v3 to actions…

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -55,7 +55,7 @@ jobs:
           python -m galaxy_importer.main redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
 
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
           path: ansible_collections/redhatinsights/eda/redhatinsights-eda-${{ needs.version_tag.outputs.version }}.tar.gz
@@ -101,7 +101,7 @@ jobs:
           python -m galaxy_importer.main redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz
 
       - name: Upload build for hub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz
           path: ansible_collections/redhatinsights/eda/redhat-insights_eda-${{ needs.version_tag.outputs.version }}.tar.gz


### PR DESCRIPTION
GH workflow failed with:
```

This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

```

This PR should fix it.
